### PR TITLE
Consider gqls files to be valid schema files

### DIFF
--- a/graphqlcodegen-maven-plugin/src/main/java/io/github/deweyjose/graphqlcodegen/SchemaFileManifest.java
+++ b/graphqlcodegen-maven-plugin/src/main/java/io/github/deweyjose/graphqlcodegen/SchemaFileManifest.java
@@ -54,7 +54,7 @@ public class SchemaFileManifest {
    * @return boolean
    */
   public static boolean isGraphqlFile(File file) {
-    return file.getName().endsWith(".graphqls") || file.getName().endsWith(".graphql");
+    return file.getName().endsWith(".graphqls") || file.getName().endsWith(".graphql") || file.getName().endsWith(".gqls");
   }
 
   /**


### PR DESCRIPTION
This aligns a bit better with Spring for GraphQL: https://docs.spring.io/spring-boot/3.4/appendix/application-properties/index.html#application-properties.web.spring.graphql.schema.file-extensions